### PR TITLE
Update exampleUsage.py to include changes to finalName

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ First, import BuildVu and setup the converter details by creating a new
 ::
 
     from BuildVuClient import BuildVu
-    buildvu = BuildVu('http://localhost:8080/microservice-example')
+    buildvu = BuildVu('http://localhost:8080/buildvu-microservice')
 
 You can now convert files by calling the methods available. ``convert()`` will 
 start the conversion process. For example to convert to html5 : 

--- a/exampleUsage.py
+++ b/exampleUsage.py
@@ -1,6 +1,6 @@
 from BuildVuClient import BuildVu
 
-buildvu = BuildVu('http://localhost:8080/microservice-example')
+buildvu = BuildVu('http://localhost:8080/buildvu-microservice')
 
 try:
     # Upload a local file to the BuildVu microservice

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_readme():
 
 setup(
     name='buildvu',
-    version='4.0.2',
+    version='4.0.3',
     description="Python API for IDRSolutions' Buildvu Microservice Example",
     long_description=get_readme(),
     url='https://github.com/idrsolutions/buildvu-python-client',


### PR DESCRIPTION
Changed buildvu variable to buildvu-microservice, this is due to the changes to the finalName in the pom.xml in buildvu-microservice-example