### PR TITLE
Fix failed request issue

### DIFF
--- a/BuildVuClient/BuildVu.py
+++ b/BuildVuClient/BuildVu.py
@@ -137,7 +137,7 @@ class BuildVu:
             r = requests.post(self.endpoint, files=files, data=params, timeout=self.request_timeout, auth=self.auth)
             r.raise_for_status()
         except requests.exceptions.RequestException as error:
-            if r is not None:
+            if 'r' in vars() and r is not None:
                 raise Exception(self.__get_returned_error_message(error, r))
             else:
                 raise Exception(error)
@@ -172,7 +172,7 @@ class BuildVu:
             r = requests.get(self.endpoint, params={'uuid': uuid}, timeout=self.request_timeout, auth=self.auth)
             r.raise_for_status()
         except requests.exceptions.RequestException as error:
-            if r is not None:
+            if 'r' in vars() and r is not None:
                 raise Exception(self.__get_returned_error_message(error, r))
             else:
                 raise Exception(error)
@@ -186,7 +186,7 @@ class BuildVu:
             r = requests.get(download_url, timeout=self.request_timeout, auth=self.auth)
             r.raise_for_status()
         except requests.exceptions.RequestException as error:
-            if r is not None:
+            if 'r' in vars() and r is not None:
                 raise Exception(self.__get_returned_error_message(error, r))
             else:
                 raise Exception(error)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_readme():
 
 setup(
     name='buildvu',
-    version='4.1.3',
+    version='4.1.4',
     description="Python API for IDRSolutions' Buildvu Microservice Example",
     long_description=get_readme(),
     url='https://github.com/idrsolutions/buildvu-python-client',


### PR DESCRIPTION
If a request fails on polling, upload, or download a request object may not be created but is checked in the except.
This fix checks if the variable exists before we try to use it.